### PR TITLE
Updated watch task to include nested folders

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,8 +107,8 @@ gulp.task('hint:html', function() {
 gulp.task('lint', ['style:js', 'hint:js', 'hint:html']);
 
 gulp.task('watch', function() {
-  gulp.watch('./sass/*.scss', ['sass']);
-  gulp.watch(['./js/*.js', './package.json'], ['browserify', 'browserify-test']);
+  gulp.watch('./sass/**/*.scss', ['sass']);
+  gulp.watch(['./js/**/*.js', './package.json'], ['browserify', 'browserify-test']);
   gulp.watch('./app/index.html', ['hint:html']);
   gulp.watch('./js/**/*.js', ['hint:js', ['style:js']]);
 });


### PR DESCRIPTION
Last night I had to restart the gulp task to get it to update for anything inside the views folder. I looked at the gulpfile and realized that nested folders were not being included in the watch task, so I have added them to the gulpfile. 